### PR TITLE
Bug fixes for regression test generation and OverridesError

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Injection chain errors attempt to be self-explanatory, but sometimes that's not 
 If you're building your injection sequence dynamically, it may be useful to print
 the injection chain.  It has a `String()` method.
 
+If you think that the issue is with nject, then open an issue with the reproduce information
+that is available as part of the debugging (`Debugging.Reproduce`) or avilable by calling
+`nject.DetailedError(err)` on the error returned from `Bind()` or `Run()`.
+
 # Related packages
 
 The following use nject to provide nicer APIs:

--- a/debug_test.go
+++ b/debug_test.go
@@ -1,8 +1,14 @@
 package nject
 
 import (
+	"fmt"
+	"regexp"
+	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func debugOn(t *testing.T) {
@@ -32,5 +38,59 @@ func wrapTest(t *testing.T, inner func(*testing.T)) {
 			defer debugOff()
 			inner(t)
 		})
+	}
+}
+
+func TestDetailedError(t *testing.T) {
+	t.Parallel()
+
+	type MyType1 struct {
+		Int int
+	}
+	type MyType2 []MyType1
+	type MyType3 *MyType1
+	type MyType4 interface {
+		String() string
+	}
+	type MyType5 interface {
+		unimplementable()
+	}
+
+	err := Run("expected-to-fail",
+		Desired(func() MyType1 { return MyType1{} }),
+		Shun(func(m MyType1) MyType3 { return &m }),
+		Required(func(m MyType3) MyType2 { return []MyType1{*m} }),
+		Cacheable(func() int { return 4 }),
+		MustCache(func() string { return "foo" }),
+		Cluster("c1",
+			Singleton(func(i int) int64 { return int64(i) }),
+			Loose(func(m MyType4) string { return m.String() }),
+		),
+		Cluster("c2",
+			Reorder(func() time.Time { return time.Now() }),
+			NotCacheable(func(i int) int32 { return int32(i) }),
+		),
+		// CallsInner(func(i func()) { i() }),
+		Memoize(func(i int32) int32 { return i }),
+		OverridesError(func(i func()) error { return nil }),
+		MustConsume(func(i int32) int64 { return int64(i) }),
+		ConsumptionOptional(func(i int64) float64 { return float64(i) }),
+		func(m MyType5) error { return nil },
+		NonFinal(func() {}),
+	)
+	require.Error(t, err, "mess from the above")
+	detailed := DetailedError(err)
+	require.NotEqual(t, err.Error(), detailed, "detailed should have more")
+	t.Log("detailed error", detailed)
+
+	index := strings.Index(detailed, "func TestRegression")
+	require.NotEqual(t, -1, index, "contains 'func TestRegression'")
+	detailed = detailed[index:]
+
+	for _, word := range strings.Split("Desired Shun Required Cacheable MustCache Cluster Memoize OverridesError MustConsume ConsumptionOptional NonFinal", " ") {
+		re := regexp.MustCompile(fmt.Sprintf(`\b%s\(` /*)*/, word))
+		if !re.MatchString(detailed) {
+			t.Errorf("did not find %s( in reproduce output", word) // )
+		}
 	}
 }

--- a/nject.go
+++ b/nject.go
@@ -17,7 +17,7 @@ type provider struct {
 	fn     interface{}
 	id     int32
 
-	// user annotations
+	// user annotations (match these in debug.go)
 	nonFinal            bool
 	cacheable           bool
 	mustCache           bool
@@ -86,6 +86,7 @@ func (fm *provider) copy() *provider {
 		memoize:             fm.memoize,
 		loose:               fm.loose,
 		reorder:             fm.reorder,
+		overridesError:      fm.overridesError,
 		desired:             fm.desired,
 		shun:                fm.shun,
 		notCacheable:        fm.notCacheable,

--- a/overrides_error_test.go
+++ b/overrides_error_test.go
@@ -32,9 +32,9 @@ func TestOverridesError(t *testing.T) {
 	t.Log("test: should fail because there is a terminal-error injector that gets clobbered")
 	assert.Error(t, Sequence("C", danger, returnsTerminal, finalWithoutError).Bind(&target, nil))
 
-	t.Log("test: okay because marked even thoguh the final function returns error that gets clobbered")
-	assert.Error(t, Sequence("B", OverridesError(danger), finalWithError).Bind(&target, nil))
+	t.Log("test: okay because marked even though the final function returns error that gets clobbered")
+	assert.NoError(t, Sequence("B", OverridesError(danger), finalWithError).Bind(&target, nil))
 
 	t.Log("test: okay because marked even though there is a terminal-error injector that gets clobbered")
-	assert.Error(t, Sequence("C", OverridesError(danger), returnsTerminal, finalWithoutError).Bind(&target, nil))
+	assert.NoError(t, Sequence("C", OverridesError(danger), returnsTerminal, finalWithoutError).Bind(&target, nil))
 }


### PR DESCRIPTION
- DetailedError() did not have a test [fixed]
- OverridesError() only partially worked [fixed]
- OverridesError() test was incorrect [fixed]
- Automatic creation of regression tests missed many decorators [fixed]
- README now has instructions for getting generated regression tests