### PR TITLE
add warning about duplicated types to DetailedError

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package nject
 
 import (
 	"errors"
+	"sync"
 )
 
 type njectError struct {
@@ -20,7 +21,44 @@ func (ne *njectError) Error() string {
 func DetailedError(err error) string {
 	var njectError *njectError
 	if errors.As(err, &njectError) {
+		dups := duplicateTypes()
+		if dups != "" {
+			return err.Error() + "\n\n" + njectError.details +
+				"\n\nWarning: the following type names refer to more than one type:\n" +
+				dups
+		}
 		return err.Error() + "\n\n" + njectError.details
 	}
 	return err.Error()
+}
+
+var duplicatesThrough int
+var dupLock sync.Mutex
+var duplicates string
+var duplicatesFound = make(map[string]struct{})
+
+func duplicateTypes() string {
+	max := func() int {
+		lock.Lock()
+		defer lock.Unlock()
+		return typeCounter
+	}()
+	dupLock.Lock()
+	defer dupLock.Unlock()
+	if duplicatesThrough == max {
+		return duplicates
+	}
+	names := make(map[string]struct{})
+	for i := 1; i <= typeCounter; i++ {
+		n := typeCode(i).String()
+		if _, ok := names[n]; ok {
+			if _, ok := duplicatesFound[n]; !ok {
+				duplicates += " " + n
+				duplicatesFound[n] = struct{}{}
+			}
+		}
+		names[n] = struct{}{}
+	}
+	duplicatesThrough = max
+	return duplicates
 }

--- a/internal/foo/foo.go
+++ b/internal/foo/foo.go
@@ -1,0 +1,3 @@
+package foo
+
+type Bar struct {}

--- a/internal/foo/v2/foo.go
+++ b/internal/foo/v2/foo.go
@@ -1,0 +1,3 @@
+package foo
+
+type Bar struct {}

--- a/type_codes_test.go
+++ b/type_codes_test.go
@@ -1,0 +1,28 @@
+package nject
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/muir/nject/internal/foo"
+	v2 "github.com/muir/nject/internal/foo/v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionedNames(t *testing.T) {
+	x1 := getTypeCode(v1.Bar{})
+	assert.Equal(t, "foo.Bar", x1.String())
+	t.Log("base type", reflect.TypeOf(v2.Bar{}).PkgPath())
+	assert.Equal(t, "foo/v2.Bar", getTypeCode(v2.Bar{}).String())
+	t.Log("pointer", reflect.TypeOf(&v2.Bar{}).PkgPath())
+	assert.Equal(t, "*foo.Bar", getTypeCode(&v2.Bar{}).String()) // :(
+	assert.Equal(t, "*foo.Bar", getTypeCode(&v1.Bar{}).String()) // :(
+	t.Log("slice", reflect.TypeOf([]v2.Bar{}).PkgPath())
+	assert.Equal(t, "[]foo.Bar", getTypeCode([]v2.Bar{}).String()) // :(
+	assert.Equal(t, "[]foo.Bar", getTypeCode([]v1.Bar{}).String()) // :(
+	dups := duplicateTypes()
+	assert.Contains(t, dups, "[]foo.Bar")
+	assert.Contains(t, dups, "*foo.Bar")
+	t.Log("duplicates", dups)
+}


### PR DESCRIPTION
I think this is the best that can be done to address the issue of duplicate types of different versions.

Closes #56 