### PR TITLE
fix: Cluster() did not work as documented

### DIFF
--- a/api.go
+++ b/api.go
@@ -73,12 +73,18 @@ var clusterId int32 = 1
 // be included at all.  It also downgrades providers that are in the
 // cluster that would normally be considered desired because they don't
 // return anything and aren't wrappers: they're no longer automatically
-// considered desired.
+// considered desired because doing so would imply the entire Cluster is
+// is desired.
+//
+// A "Cluster" with only one member is not really a cluster and will
+// not be treated as a cluster.
 func Cluster(name string, providers ...interface{}) *Collection {
 	c := newCollection(name, providers...)
-	id := atomic.AddInt32(&clusterId, 1)
-	for _, fm := range c.contents {
-		fm.cluster = id
+	if len(providers) > 1 {
+		id := atomic.AddInt32(&clusterId, 1)
+		for _, fm := range c.contents {
+			fm.cluster = id
+		}
 	}
 	return c
 }

--- a/debug_test.go
+++ b/debug_test.go
@@ -32,8 +32,12 @@ func debugOff() {
 }
 
 func wrapTest(t *testing.T, inner func(*testing.T)) {
-	if !t.Run("1st attempt", func(t *testing.T) { inner(t) }) {
-		t.Run("2nd attempt", func(t *testing.T) {
+	namedWrapTest(t, "", inner)
+}
+
+func namedWrapTest(t *testing.T, name string, inner func(*testing.T)) {
+	if !t.Run("1st attempt"+name, func(t *testing.T) { inner(t) }) {
+		t.Run("2nd attempt"+name, func(t *testing.T) {
 			debugOn(t)
 			defer debugOff()
 			inner(t)

--- a/example_cluster_test.go
+++ b/example_cluster_test.go
@@ -15,6 +15,10 @@ func ExampleCluster() {
 			func(s string) int32 {
 				return int32(len(s))
 			},
+			func() int64 {
+				fmt.Println("included even though no consumer")
+				return 0
+			},
 			func(i int32) {
 				fmt.Println("auto-desired in 1st cluster")
 			},
@@ -47,6 +51,7 @@ func ExampleCluster() {
 		},
 	)
 	// Output: no need for data from clusters
+	// included even though no consumer
 	// auto-desired in 1st cluster
 	// auto-desired in 2nd cluster
 	// got value that needed both chains - 28


### PR DESCRIPTION
Cluster() did keep members that did not provide types that were used downstream.
That is contrary to the documentation.

This is a change in behavior.

fixes #66 