### PR TITLE
[feat] BREAKING CHANGE: replace OverridesError with AllowReturnShadowing

### DIFF
--- a/api.go
+++ b/api.go
@@ -518,14 +518,6 @@ func MustRun(name string, providers ...any) {
 
 // MustBindSimple binds a collection with an invoke function that takes no
 // arguments and returns no arguments.  It panic()s if Bind() returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustBindSimple(c *Collection, _ string) func() {
-	return c.MustBindSimple()
-}
-
-// MustBindSimple binds a collection with an invoke function that takes no
-// arguments and returns no arguments.  It panic()s if Bind() returns error.
 func (c *Collection) MustBindSimple() func() {
 	var invoke func()
 	c.MustBind(&invoke, nil)
@@ -533,26 +525,10 @@ func (c *Collection) MustBindSimple() func() {
 }
 
 // MustBindSimpleError binds a collection with an invoke function that takes no
-// arguments and returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustBindSimpleError(c *Collection, _ string) func() error {
-	return c.MustBindSimpleError()
-}
-
-// MustBindSimpleError binds a collection with an invoke function that takes no
-// arguments and returns no arguments.  It panic()s if Bind() returns error.
 func (c *Collection) MustBindSimpleError() func() error {
 	var invoke func() error
 	c.MustBind(&invoke, nil)
 	return invoke
-}
-
-// MustBind is a wrapper for Collection.Bind().  It panic()s if Bind() returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustBind(c *Collection, invokeFunc any, initFunc any) {
-	c.MustBind(invokeFunc, initFunc)
 }
 
 // MustBind is a wrapper for Collection.Bind().  It panic()s if Bind() returns error.
@@ -561,13 +537,6 @@ func (c *Collection) MustBind(invokeFunc any, initFunc any) {
 	if err != nil {
 		panic(DetailedError(err))
 	}
-}
-
-// MustSetCallback is a wrapper for Collection.SetCallback().  It panic()s if SetCallback() returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustSetCallback(c *Collection, binderFunction any) {
-	c.MustSetCallback(binderFunction)
 }
 
 // MustSetCallback is a wrapper for Collection.SetCallback().  It panic()s if SetCallback() returns error.

--- a/bind.go
+++ b/bind.go
@@ -31,11 +31,6 @@ func doBind(sc *Collection, originalInvokeF *provider, originalInitF *provider, 
 			return err
 		}
 
-		err = checkForMissingOverridesError(afterInvoke)
-		if err != nil {
-			return err
-		}
-
 		// Add debugging provider
 		{
 			//nolint:govet // err is shadowing, who cares?
@@ -122,6 +117,11 @@ func doBind(sc *Collection, originalInvokeF *provider, originalInitF *provider, 
 	// fm.whyIncluded, fm.include
 	var err error
 	funcs, err = computeDependenciesAndInclusion(funcs, initF)
+	if err != nil {
+		return err
+	}
+
+	err = checkForShadowing(funcs)
 	if err != nil {
 		return err
 	}

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,7 +1,5 @@
 package nject
 
-// TODO: Test MustBindSimple
-// TODO: Test MustBindSimpleError
 // TODO: write more examples
 // TODO: do a bunch of bind init and invoke in parallel to exercise the locks
 // TODO: test Then
@@ -233,7 +231,7 @@ func TestInitDependencyOnUnavailableData(t *testing.T) {
 		err := c.Bind(&shouldWorkInvoke, &shouldWorkInit)
 		require.Error(t, err)
 		assert.Panics(t, func() {
-			MustBind(c, &shouldWorkInvoke, &shouldWorkInit)
+			c.MustBind(&shouldWorkInvoke, &shouldWorkInit)
 		})
 	})
 }
@@ -332,7 +330,7 @@ func TestLiteral(t *testing.T) {
 		)
 		var shouldWorkInit func(s0) s2
 		var shouldWorkInvoke func(s3) s5
-		MustBind(c, &shouldWorkInvoke, &shouldWorkInit)
+		c.MustBind(&shouldWorkInvoke, &shouldWorkInit)
 		assert.Equal(t, s2Value, shouldWorkInit("s0 value"))
 		assert.Equal(t, s2Value, shouldWorkInit("ignored"))
 		assert.Equal(t, s5Value, shouldWorkInvoke(s3Value))

--- a/debug.go
+++ b/debug.go
@@ -248,7 +248,6 @@ func generateReproduce(funcs []*provider, invokeF *provider, initF *provider) st
 			"Memoize":             fm.memoize,
 			"Loose":               fm.loose,
 			"Reorder":             fm.reorder,
-			"OverridesError":      fm.overridesError,
 			"Desired":             fm.desired,
 			"Shun":                fm.shun,
 			"NotCacheable":        fm.notCacheable,
@@ -260,6 +259,10 @@ func generateReproduce(funcs []*provider, invokeF *provider, initF *provider) st
 				f += annotation + "("
 				closeParens += ")"
 			}
+		}
+		for tc := range fm.shadowingAllowed {
+			f += "ShadowingAllowed[" + tc.String() + "]("
+			closeParens += ")"
 		}
 		n := fm.origin
 		if fm.index != -1 {

--- a/debug_test.go
+++ b/debug_test.go
@@ -93,7 +93,7 @@ func TestDetailedError(t *testing.T) {
 	require.NotEqual(t, -1, index, "contains 'func TestRegression'")
 	detailed = detailed[index:]
 
-	for _, word := range strings.Split("Desired Shun Required Cacheable MustCache Cluster Memoize OverridesError MustConsume ConsumptionOptional NonFinal", " ") {
+	for _, word := range strings.Split("Desired Shun Required Cacheable MustCache Cluster Memoize ShadowingAllowed\\[error\\] MustConsume ConsumptionOptional NonFinal", " ") {
 		re := regexp.MustCompile(fmt.Sprintf(`\b%s\(` /*)*/, word))
 		if !re.MatchString(detailed) {
 			t.Errorf("did not find %s( in reproduce output", word) // )

--- a/example_allow_shadowing_test.go
+++ b/example_allow_shadowing_test.go
@@ -1,0 +1,22 @@
+package nject_test
+
+import (
+	"fmt"
+
+	"github.com/muir/nject"
+)
+
+func ExampleAllowReturnShadowing() {
+	fmt.Println(nject.Run("error is shadowed",
+		nject.AllowReturnShadowing[error](nject.Provide("footgun", func(inner func()) error {
+			inner()
+			return nil
+		})),
+		func() error {
+			fmt.Println("error is generated")
+			return fmt.Errorf("this error is dropped")
+		},
+	))
+	// Output: error is generated
+	// <nil>
+}

--- a/example_bind_test.go
+++ b/example_bind_test.go
@@ -75,22 +75,6 @@ func ExampleCollection_Bind_passing_in_parameters() {
 	// 47
 }
 
-func ExampleMustBindSimple() {
-	f := nject.MustBindSimple(
-		nject.Sequence("example",
-			func() int {
-				return 7
-			},
-			func(i int) {
-				fmt.Println(i)
-			},
-		), "bind-name")
-	f()
-	f()
-	// Output: 7
-	// 7
-}
-
 func ExampleCollection_MustBindSimple() {
 	f := nject.Sequence("example",
 		func() int {
@@ -104,22 +88,6 @@ func ExampleCollection_MustBindSimple() {
 	f()
 	// Output: 7
 	// 7
-}
-
-func ExampleMustBindSimpleError() {
-	f := nject.MustBindSimpleError(
-		nject.Sequence("example",
-			func() int {
-				return 7
-			},
-			func(i int) error {
-				fmt.Println(i)
-				return nil
-			},
-		), "bind-name")
-	fmt.Println(f())
-	// Output: 7
-	// <nil>
 }
 
 func ExampleCollection_MustBindSimpleError() {

--- a/example_setcallback_test.go
+++ b/example_setcallback_test.go
@@ -42,22 +42,3 @@ func ExampleCollection_MustSetCallback() {
 	// Output: got foo 3
 	// got bar 3
 }
-
-// SetCallback invokes a function passing a function that
-// can be used to invoke a Collection
-func ExampleMustSetCallback() {
-	var cb func(string)
-	nject.MustSetCallback(
-		nject.Sequence("example",
-			func() int { return 3 },
-			func(s string, i int) {
-				fmt.Println("got", s, i)
-			},
-		), func(f func(string)) {
-			cb = f
-		})
-	cb("foo")
-	cb("bar")
-	// Output: got foo 3
-	// got bar 3
-}

--- a/nject.go
+++ b/nject.go
@@ -26,7 +26,6 @@ type provider struct {
 	memoize             bool
 	loose               bool
 	reorder             bool
-	overridesError      bool
 	desired             bool
 	shun                bool
 	notCacheable        bool
@@ -38,6 +37,7 @@ type provider struct {
 	replaceByName       string
 	insertBeforeName    string
 	insertAfterName     string
+	shadowingAllowed    map[typeCode]struct{}
 
 	// added by characterize
 	memoized    bool
@@ -90,7 +90,6 @@ func (fm *provider) copy() *provider {
 		memoize:             fm.memoize,
 		loose:               fm.loose,
 		reorder:             fm.reorder,
-		overridesError:      fm.overridesError,
 		desired:             fm.desired,
 		shun:                fm.shun,
 		notCacheable:        fm.notCacheable,
@@ -108,6 +107,7 @@ func (fm *provider) copy() *provider {
 		replaceByName:       fm.replaceByName,
 		insertBeforeName:    fm.insertBeforeName,
 		insertAfterName:     fm.insertAfterName,
+		shadowingAllowed:    mapCopy(fm.shadowingAllowed),
 	}
 }
 

--- a/nject_test.go
+++ b/nject_test.go
@@ -73,6 +73,19 @@ func TestAnnotateLoose(t *testing.T) {
 	})
 }
 
+func TestAnnotateShadowing(t *testing.T) {
+	stc := getTypeCode("foo")
+	wrapTest(t, func(t *testing.T) {
+		var counter int
+		p := AllowReturnShadowing[string](func() { counter++ })
+		require.IsType(t, &provider{}, p)
+		require.NotNil(t, p.(*provider).shadowingAllowed)
+		require.Contains(t, p.(*provider).shadowingAllowed, stc)
+		require.NotNil(t, p.(*provider).copy().shadowingAllowed)
+		require.Contains(t, p.(*provider).copy().shadowingAllowed, stc)
+	})
+}
+
 func TestAnnotateDesired(t *testing.T) {
 	wrapTest(t, func(t *testing.T) {
 		var counter int

--- a/overrides_error.go
+++ b/overrides_error.go
@@ -1,10 +1,5 @@
 package nject
 
-import (
-	"fmt"
-	"reflect"
-)
-
 // OverridesError marks a provider that is okay for that provider to override
 // error returns.  Without this decorator, a wrapper that returns error but
 // does not expect to receive an error will cause the injection chain
@@ -49,37 +44,8 @@ import (
 //		}()
 //		return inner(thing)
 //	}
+//
+// Deprecated: use AllowReturnShadowing instead
 func OverridesError(fn any) Provider {
-	return newThing(fn).modify(func(fm *provider) {
-		fm.overridesError = true
-	})
-}
-
-func checkForMissingOverridesError(collection []*provider) error {
-	var errorReturnSeen bool
-	for i := len(collection) - 1; i >= 0; i-- {
-		fm := collection[i]
-		if errorReturnSeen && !fm.overridesError && fm.class == wrapperFunc {
-			consumes, returns := fm.UpFlows()
-			if hasError(returns) && !hasError(consumes) {
-				return fmt.Errorf("wrapper returns error but does not consume error.  Decorate with OverridesError() if this is intentional. %s", fm)
-			}
-		}
-		if !errorReturnSeen {
-			_, returns := fm.UpFlows()
-			if hasError(returns) {
-				errorReturnSeen = true
-			}
-		}
-	}
-	return nil
-}
-
-func hasError(types []reflect.Type) bool {
-	for _, typ := range types {
-		if typ == errorType {
-			return true
-		}
-	}
-	return false
+	return AllowReturnShadowing[error](fn)
 }

--- a/reorder_test.go
+++ b/reorder_test.go
@@ -51,9 +51,9 @@ func TestReorderWrappers(t *testing.T) {
 	var invoke func(R02) R03
 	require.NoError(t, Sequence(t.Name(),
 		Memoize(func(r00 R00) (R01, R04) { return R01(r00) + "A", R04(r00) + "A" }),
-		Reorder(func(inner func(r04 R04) R06, r04 R04) R05 {
+		AllowReturnShadowing[R05](Reorder(func(inner func(r04 R04) R06, r04 R04) R05 {
 			return R05(inner(r04+"C1")) + "C2"
-		}),
+		})),
 		Reorder(func(inner func(r04 R04) R05, r04 R04) {
 			_ = inner(r04 + "B1")
 		}),
@@ -79,9 +79,9 @@ func TestReorderChaos(t *testing.T) {
 			x := inner("<" + R07(r06) + ">E1")
 			return "<" + R09(x) + ">E2", "<" + R10(x) + ">E3"
 		},
-		func(inner func(R06) R09, r05 R05) R10 {
+		AllowReturnShadowing[R10](func(inner func(R06) R09, r05 R05) R10 {
 			return "<" + R10(inner("<"+R06(r05)+">F1")) + ">F2"
-		},
+		}),
 		func(r02 R02) R03 { return "<" + R03(r02) + ">G" },
 		func(r04 R04, r06 R06) R07 { return "<" + R07(r04) + "><" + R07(r06) + ">H" },
 		func(r03 R03) R06 { return "<" + R06(r03) + ">I" },
@@ -104,10 +104,10 @@ func TestReorderUnused(t *testing.T) {
 		func(r00 R00, r01 R01) R00 { return "<" + r00 + R00(r01) + ">B" },
 		func() R01 { return "<C>" },
 		func(r05 R05) (R06, R04) { return "<" + R06(r05) + ">D1", "<" + R04(r05) + ">D2" },
-		func(inner func(R07) R08, r06 R06) (R09, R10) {
+		AllowReturnShadowing[R10](func(inner func(R07) R08, r06 R06) (R09, R10) {
 			x := inner("<" + R07(r06) + ">E1")
 			return "<" + R09(x) + ">E2", "<" + R10(x) + ">E3"
-		},
+		}),
 		func(inner func(R06) R09, r05 R05) R10 {
 			return "<" + R10(inner("<"+R06(r05)+">F1")) + ">F2"
 		},

--- a/shadowing.go
+++ b/shadowing.go
@@ -1,0 +1,45 @@
+package nject
+
+import "fmt"
+
+func checkForShadowing(funcs []*provider) error {
+	returnedValues := make(map[typeCode]int)
+	for i := len(funcs) - 1; i >= 0; i-- {
+		fm := funcs[i]
+		recevied := make(map[typeCode]bool)
+		for _, tc := range fm.flows[receivedParams] {
+			recevied[tc] = true
+		}
+		for _, tc := range fm.flows[returnParams] {
+			if recevied[tc] {
+				continue
+			}
+			from, ok := returnedValues[tc]
+			if !ok {
+				returnedValues[tc] = i
+				continue
+			}
+			if (fm.class == fallibleStaticInjectorFunc || fm.class == fallibleInjectorFunc) &&
+				(tc == errorTypeCode || tc == terminalErrorTypeCode) {
+				returnedValues[tc] = i
+				continue
+			}
+			if _, ok = fm.shadowingAllowed[tc]; ok {
+				continue
+			}
+			return fmt.Errorf("%s returns %s overriding the return from %s, use AllowReturnShadowing to suppress this error", fm.String(), tc.String(), funcs[from].String())
+		}
+	}
+	return nil
+}
+
+func mapCopy[K comparable, V any](m map[K]V) map[K]V {
+	if m == nil {
+		return nil
+	}
+	n := make(map[K]V)
+	for k, v := range m {
+		n[k] = v
+	}
+	return n
+}

--- a/shadowing_test.go
+++ b/shadowing_test.go
@@ -1,0 +1,68 @@
+package nject_test
+
+import (
+	"testing"
+
+	"github.com/muir/nject"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShadowingAnnotation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		valid   bool
+		wrapper nject.Provider
+	}{
+		{
+			name:  "noGun",
+			valid: true,
+			wrapper: nject.Provide("nogun", func(inner func() error) error {
+				return inner()
+			}),
+		},
+		{
+			name:  "footgun",
+			valid: false,
+			wrapper: nject.Provide("gun", func(inner func()) error {
+				inner()
+				return nil
+			}),
+		},
+		{
+			name:  "forced",
+			valid: true,
+			wrapper: nject.AllowReturnShadowing[error](nject.Provide("gun", func(inner func()) error {
+				inner()
+				return nil
+			})),
+		},
+		{
+			name:  "wrong",
+			valid: false,
+			wrapper: nject.AllowReturnShadowing[string](nject.Provide("gun", func(inner func()) error {
+				inner()
+				return nil
+			})),
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			c := nject.Sequence(tc.name,
+				tc.wrapper,
+				func() error {
+					return nil
+				},
+			)
+			var invoke func() error
+			err := c.Bind(&invoke, nil)
+			if tc.valid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				t.Logf("error is %s", err.Error())
+			}
+		})
+	}
+}

--- a/type_codes.go
+++ b/type_codes.go
@@ -29,6 +29,10 @@ var noTypeCode = getTypeCode(noTypeExampleValue)
 
 var unusedTypeCode = getTypeCode(unusedType)
 
+var errorTypeCode = getTypeCode(errorType)
+
+var terminalErrorTypeCode = getTypeCode(terminalErrorType)
+
 // noNoType filters out noTypeCode from an array of typeCode
 func noNoType(types []typeCode) []typeCode {
 	found := -1

--- a/unused_test.go
+++ b/unused_test.go
@@ -79,6 +79,13 @@ func TestUnused(t *testing.T) {
 		callsExpected int
 	}{
 		{
+			name: "unused as constant",
+			chain: []any{
+				Unused{},
+				func() { called = true },
+			},
+		},
+		{
 			name: "add unused injector",
 			chain: []any{
 				17,


### PR DESCRIPTION
Unsafe returns from wrapper functions are now an error. This is a breaking change.