### PR TITLE
[chore] BREAKING CHANGE: remove deprecated functions

### DIFF
--- a/api.go
+++ b/api.go
@@ -518,14 +518,6 @@ func MustRun(name string, providers ...any) {
 
 // MustBindSimple binds a collection with an invoke function that takes no
 // arguments and returns no arguments.  It panic()s if Bind() returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustBindSimple(c *Collection, _ string) func() {
-	return c.MustBindSimple()
-}
-
-// MustBindSimple binds a collection with an invoke function that takes no
-// arguments and returns no arguments.  It panic()s if Bind() returns error.
 func (c *Collection) MustBindSimple() func() {
 	var invoke func()
 	c.MustBind(&invoke, nil)
@@ -533,26 +525,10 @@ func (c *Collection) MustBindSimple() func() {
 }
 
 // MustBindSimpleError binds a collection with an invoke function that takes no
-// arguments and returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustBindSimpleError(c *Collection, _ string) func() error {
-	return c.MustBindSimpleError()
-}
-
-// MustBindSimpleError binds a collection with an invoke function that takes no
-// arguments and returns no arguments.  It panic()s if Bind() returns error.
 func (c *Collection) MustBindSimpleError() func() error {
 	var invoke func() error
 	c.MustBind(&invoke, nil)
 	return invoke
-}
-
-// MustBind is a wrapper for Collection.Bind().  It panic()s if Bind() returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustBind(c *Collection, invokeFunc any, initFunc any) {
-	c.MustBind(invokeFunc, initFunc)
 }
 
 // MustBind is a wrapper for Collection.Bind().  It panic()s if Bind() returns error.
@@ -561,13 +537,6 @@ func (c *Collection) MustBind(invokeFunc any, initFunc any) {
 	if err != nil {
 		panic(DetailedError(err))
 	}
-}
-
-// MustSetCallback is a wrapper for Collection.SetCallback().  It panic()s if SetCallback() returns error.
-//
-// Deprecated: use the method on Collection instead
-func MustSetCallback(c *Collection, binderFunction any) {
-	c.MustSetCallback(binderFunction)
 }
 
 // MustSetCallback is a wrapper for Collection.SetCallback().  It panic()s if SetCallback() returns error.

--- a/bind_test.go
+++ b/bind_test.go
@@ -1,7 +1,5 @@
 package nject
 
-// TODO: Test MustBindSimple
-// TODO: Test MustBindSimpleError
 // TODO: write more examples
 // TODO: do a bunch of bind init and invoke in parallel to exercise the locks
 // TODO: test Then
@@ -233,7 +231,7 @@ func TestInitDependencyOnUnavailableData(t *testing.T) {
 		err := c.Bind(&shouldWorkInvoke, &shouldWorkInit)
 		require.Error(t, err)
 		assert.Panics(t, func() {
-			MustBind(c, &shouldWorkInvoke, &shouldWorkInit)
+			c.MustBind(&shouldWorkInvoke, &shouldWorkInit)
 		})
 	})
 }
@@ -332,7 +330,7 @@ func TestLiteral(t *testing.T) {
 		)
 		var shouldWorkInit func(s0) s2
 		var shouldWorkInvoke func(s3) s5
-		MustBind(c, &shouldWorkInvoke, &shouldWorkInit)
+		c.MustBind(&shouldWorkInvoke, &shouldWorkInit)
 		assert.Equal(t, s2Value, shouldWorkInit("s0 value"))
 		assert.Equal(t, s2Value, shouldWorkInit("ignored"))
 		assert.Equal(t, s5Value, shouldWorkInvoke(s3Value))

--- a/example_bind_test.go
+++ b/example_bind_test.go
@@ -75,22 +75,6 @@ func ExampleCollection_Bind_passing_in_parameters() {
 	// 47
 }
 
-func ExampleMustBindSimple() {
-	f := nject.MustBindSimple(
-		nject.Sequence("example",
-			func() int {
-				return 7
-			},
-			func(i int) {
-				fmt.Println(i)
-			},
-		), "bind-name")
-	f()
-	f()
-	// Output: 7
-	// 7
-}
-
 func ExampleCollection_MustBindSimple() {
 	f := nject.Sequence("example",
 		func() int {
@@ -104,22 +88,6 @@ func ExampleCollection_MustBindSimple() {
 	f()
 	// Output: 7
 	// 7
-}
-
-func ExampleMustBindSimpleError() {
-	f := nject.MustBindSimpleError(
-		nject.Sequence("example",
-			func() int {
-				return 7
-			},
-			func(i int) error {
-				fmt.Println(i)
-				return nil
-			},
-		), "bind-name")
-	fmt.Println(f())
-	// Output: 7
-	// <nil>
 }
 
 func ExampleCollection_MustBindSimpleError() {

--- a/example_setcallback_test.go
+++ b/example_setcallback_test.go
@@ -42,22 +42,3 @@ func ExampleCollection_MustSetCallback() {
 	// Output: got foo 3
 	// got bar 3
 }
-
-// SetCallback invokes a function passing a function that
-// can be used to invoke a Collection
-func ExampleMustSetCallback() {
-	var cb func(string)
-	nject.MustSetCallback(
-		nject.Sequence("example",
-			func() int { return 3 },
-			func(s string, i int) {
-				fmt.Println("got", s, i)
-			},
-		), func(f func(string)) {
-			cb = f
-		})
-	cb("foo")
-	cb("bar")
-	// Output: got foo 3
-	// got bar 3
-}


### PR DESCRIPTION
Removes `MustBindSimple`, `MustBindSimpleError`, `MustBind`, and `MustSetCallback` functions that have been deprecated for a long time.