### PR TITLE
DetailedError will not panic on nil error

### DIFF
--- a/debug_test.go
+++ b/debug_test.go
@@ -100,3 +100,9 @@ func TestDetailedError(t *testing.T) {
 		}
 	}
 }
+
+func TestNilDetailedError(t *testing.T) {
+	t.Parallel()
+	var err error
+	require.NoError(t, err, DetailedError(err))
+}

--- a/error.go
+++ b/error.go
@@ -19,6 +19,9 @@ func (ne *njectError) Error() string {
 // or something that called Bind() then it will return
 // a much more detailed error than just calling err.Error()
 func DetailedError(err error) string {
+	if err == nil {
+		return ""
+	}
 	var njectError *njectError
 	if errors.As(err, &njectError) {
 		dups := duplicateTypes()


### PR DESCRIPTION
Let `DetailedError` return an empty string when called with `nil`. That allows:

```
require.NoError(t, err, nject.DetailedError(err))
```
