### PR TITLE
[fix] lint fix; test with go 1.23 & 1.24

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: '1.21'
+          go-version: '1.22'
       - name: Run coverage
         run: go test -race -coverprofile=coverage.out -covermode=atomic
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x, 1.23.x, 1.24.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/example_db_test.go
+++ b/example_db_test.go
@@ -106,7 +106,7 @@ func Example_transaction() {
 	nject.MustRun("B", upstream, InjectDB("dummy", "ignored", nil),
 		func(db *sql.DB) error {
 			//nolint:sqlclosecheck // we don't care
-			_, _ = db.Prepare("ignored") // database opens are lazy so this triggers the logging
+			_, _ = db.PrepareContext(context.TODO(), "ignored") // database opens are lazy so this triggers the logging
 			fmt.Println("final-func")
 			return nil
 		})


### PR DESCRIPTION
Updates code to pass the current lint
Runs tests against more recent Go versions